### PR TITLE
🔨 Add golangci-lint Workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+# Add workflow to run golangci-lint on pull requests
+
+name: golangci-lint
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.5
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1
+          args: --timeout 2m
+          only-new-issues: true


### PR DESCRIPTION
This commit adds a golangci-lint workflow, to lint proposed commits in PRs raised.