### PR TITLE
👷 Add Automatic Deployment to Production on PR Merge

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -1,0 +1,17 @@
+name: deploy-to-prod
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy-to-production:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only -c infrastructure/production/fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_PRODUCTION }}


### PR DESCRIPTION
This commit adds a GitHub Action that will automatically deploy the chat bot to the production instance of Slack when an approved PR is merged into the main branch of the repo.